### PR TITLE
Core/Spell: Rewrite dispel handling.

### DIFF
--- a/src/game/SpellAuras.h
+++ b/src/game/SpellAuras.h
@@ -193,6 +193,8 @@ class MANGOS_DLL_SPEC SpellAuraHolder
         void SetAuraFlag(uint32 slot, bool add);
         void SetAuraLevel(uint32 slot, uint32 level);
 
+        int32 CalcDispelChance(Unit* auraTarget, bool offensive) const;
+
         ~SpellAuraHolder();
     private:
         void UpdateAuraApplication();                       // called at charges or stack changes

--- a/src/game/Unit.h
+++ b/src/game/Unit.h
@@ -1975,6 +1975,9 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         virtual bool CanSwim() const = 0;
         virtual bool CanFly() const = 0;
 
+        typedef std::list <std::pair<SpellAuraHolder*, uint32> > dispelList;
+        void GetDispellableAuraList(Unit* caster, uint32 dispelMask, dispelList& dispelList);
+
     protected:
         explicit Unit();
 


### PR DESCRIPTION
New functions:

GetDispellableAuraList - creates a list with dispellable auras (from TC)
CalcDispelChance - calculates the dispel chance for a aura holder (from TC)

Player can no longer cast dispel on targets with aura's that have a 100% dispel resist chance.